### PR TITLE
Remove noexcept from throwing function

### DIFF
--- a/include/vague/unscented_transform.hpp
+++ b/include/vague/unscented_transform.hpp
@@ -16,7 +16,7 @@ struct JulierSigmaPoints {
 
 template <typename StateSpace, typename Scalar>
 WeightedSamples<StateSpace, Scalar, StateSpace::N * 2> sample(MeanAndCovariance<StateSpace, Scalar> distribution,
-                                                              unscented_transform::CubatureSigmaPoints /*unused*/) noexcept {
+                                                              unscented_transform::CubatureSigmaPoints /*unused*/) {
     Eigen::LLT<Eigen::Matrix<Scalar, StateSpace::N, StateSpace::N>> llt_solver(distribution.covariance);
     Eigen::Matrix<Scalar, StateSpace::N, StateSpace::N> sqrt_sigma;
     if (llt_solver.info() != Eigen::Success) {


### PR DESCRIPTION
```c++
vague/unscented_transform.hpp:27:13: warning: 'sample<>' has a non-throwing exception specification but can still throw [-Wexceptions]
   27 |             throw std::runtime_error("LLT and LDLT solvers failed on the covariance matrix");
      |             ^
```